### PR TITLE
Minor adaptations for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In order to benchmark the algorithm use `perf` (for now -- sorry non-linux users
 and then do
 ```bash
 exe_path=benchmark_${version}.out && \
-g++ -march=native -fopenmp -Wall -Og -std=c++17 -o $exe_path benchmark.cpp && \
+g++ -D THRD_CNT=2 -march=native -fopenmp -Wall -Og -std=c++17 -o $exe_path benchmark.cpp && \
 perf stat -e cycles:u,instructions:u ./$exe_path $version
 ```
 

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -1,11 +1,13 @@
-#ifdef __AVX512F__
-#define SSE_S 16
-#elif defined __AVX2__
-#define SSE_S 8
-#elif defined __SSE2__ && defined __SSE4_1__
-#define SSE_S 4
-#else
-#define SSE_S 0
+#ifndef SSE_S
+	#ifdef __AVX512F__
+	#define SSE_S 16
+	#elif defined __AVX2__
+	#define SSE_S 8
+	#elif defined __SSE2__ && defined __SSE4_1__
+	#define SSE_S 4
+	#else
+	#define SSE_S 1
+	#endif
 #endif
 
 
@@ -105,7 +107,7 @@ int main(int argc, char** argv)
 {
 	auto num_pairs  = 1u << 13;
 	auto string_len = 1u << 10;
-	omp_set_num_threads( 1 );
+	omp_set_num_threads( THRD_CNT );
 	
 	std::string version(argv[argc - 1]);
 	std::vector<std::string> versions_list = { 

--- a/sw_multicore_alpern.cpp
+++ b/sw_multicore_alpern.cpp
@@ -209,11 +209,11 @@ template < typename T >
         std::cout << "Using 512 bits wide registers over 16 elements per register ..." << std::endl;
         #elif defined __AVX2__
         std::cout << "Using 256 bits wide registers over 8 elements per register ..." << std::endl;
-        #elif defined __SSE2__ && defined __SSE4_1__
-        std::cout << "Using 128 bits wide registers over 4 elements per register ..." << std::endl;
         #else
-        std::cout << "Your CPU does not support SIMD instructions that are required to run this code. This implementation expects either SSE4.1, AVX2 or AVX512 support." << std::endl;
+        std::cout << "Your CPU does not support SIMD instructions that are required to run this code. This implementation expects either AVX2 or AVX512 support." << std::endl;
         #endif
+
+        std::cout << "Threads quantity: " << THRD_CNT << std::endl;
         
         // TODO switch from std::pair to using std::vector
         unsigned int const size     = sequences[0].first.size();


### PR DESCRIPTION
Check readme and new running command.

`-D THRD_CNT=<number-of-threads>` is now required to specify number of threads.

Also, adding `-D SSE_S=<sse-size>` will coerce SSE_S to be equal to `<sse-size>` regardless of the actual size of SSE registers.